### PR TITLE
Update European Parliament endpoint

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ spring.flyway.locations=classpath:/db/migration/common
 api.uk.parliament=http://data.parliament.uk/membersdataplatform/services/mnisv1.0/members/query/House=%s
 api.scottish.parliament=https://data.parliament.scot/api/members
 api.ni.assembly=http://data.niassembly.gov.uk/members.asmx/GetAllCurrentMembers
-api.european.parliament=http://www.europarl.europa.eu/meps/en/xml.html?country=GB
+api.european.parliament=https://www.europarl.europa.eu/meps/en/download/advanced/xml?countryCode=GB
 api.welsh.assembly=http://senedd.assembly.wales/mgwebservice.asmx/GetCouncillorsByWard
 
 alf.api.user=admin


### PR DESCRIPTION
The old endpoint now redirects to a HTML page, which meant that Members
of the European Parliament could not be updated, which in turn meant
that updates for all subsequent legislatures listed in
HouseService.updateWebMemberLists() never occurred, causing the list of
MPs to be significantly out of date.

This commit moves the endpoint to the new one.